### PR TITLE
Fix automatic gradient stops calculation

### DIFF
--- a/lib/nib/gradients.styl
+++ b/lib/nib/gradients.styl
@@ -1,4 +1,3 @@
-
 @import 'config'
 
 /*
@@ -37,7 +36,7 @@ pos-in-stops(i, stops)
   if len - 1 == i
     100%
   else if i
-    unit(i / len * 100, '%')
+    unit(i / (len - 1) * 100, '%')
   else
     0%
 


### PR DESCRIPTION
To get correct gradient stop positions, 100% has to be divided with the number of gaps, which is 1 less than the amount of specified colors.
