### PR TITLE
stylus as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
     "type": "git",
     "url": "git://github.com/visionmedia/nib.git"
   },
-  "dependencies": {
-    "stylus": "0.54.5"
+  "peerDependencies": {
+    "stylus": "*"
   },
   "devDependencies": {
     "connect": "1.x",
     "jade": "0.22.0",
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "stylus": "~0.54.5"
   },
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "lib/nib.js",


### PR DESCRIPTION
stylus as peer dependency (any version)
set a version as dev dependency to allow tests to run

fixes #296