### PR TITLE
Remove vendor prefix for background-size

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -283,7 +283,6 @@ Here is the full list of properties for which Nib provides transparent mixins:
 - column-rule-width
 - column-rule-style
 - column-width
-- background-size
 - transform
 - border-image
 - transition

--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -169,13 +169,6 @@ background-origin()
   background-origin: arguments
 
 /*
- * Vendor "background-size" support.
- */
-
-background-size()
-  vendor('background-size', arguments, only: webkit moz official)
-
-/*
  * Vendor "transform" support.
  */
 

--- a/test/cases/importance.css
+++ b/test/cases/importance.css
@@ -77,8 +77,6 @@
   -webkit-background-origin: padding !important;
   -moz-background-origin: padding !important;
   background-origin: padding-box !important;
-  -webkit-background-size: 0 !important;
-  -moz-background-size: 0 !important;
   background-size: 0 !important;
   background: none !important;
   -webkit-box-shadow: 0 1px 0 #000 !important;


### PR DESCRIPTION
I noticed Firefox complaining about my `-moz-background-size` declarations.  I took a peek and caniuse.com says `background-size` [has been standard](https://caniuse.com/#search=background-size) for a long time.