### PR TITLE
Use official column-fill property

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -128,7 +128,7 @@ column-span()
  */
 
 column-fill()
-  vendor('column-fill', arguments, only: moz)
+  vendor('column-fill', arguments, only: moz official)
 
 /*
  * Legacy syntax support for background-clip and background-origin


### PR DESCRIPTION
This PR fixes [`column-fill`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-fill) property, making it work on non-Firefox browsers.