### PR TITLE
Updated stylus dependencies to 0.54.8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/visionmedia/nib.git"
   },
   "dependencies": {
-    "stylus": "0.54.5"
+    "stylus": "^0.54.8"
   },
   "devDependencies": {
     "connect": "1.x",


### PR DESCRIPTION
Fix https://github.com/stylus/nib/issues/347, remove NodeJS 14 warnings.